### PR TITLE
Fix context token count to include cached tokens

### DIFF
--- a/packages/agent-worker/src/agent_worker/event_mapper.py
+++ b/packages/agent-worker/src/agent_worker/event_mapper.py
@@ -67,6 +67,20 @@ def map_assistant_message(msg: AssistantMessage) -> list[agent_pb2.AgentEvent]:
     return events
 
 
+def _total_input_tokens(usage: dict) -> int:
+    """Compute total context size including cached tokens.
+
+    The Claude API splits input tokens across three fields when prompt caching
+    is active: input_tokens (non-cached), cache_read_input_tokens, and
+    cache_creation_input_tokens. The sum represents the actual context window usage.
+    """
+    return (
+        usage.get("input_tokens", 0)
+        + usage.get("cache_read_input_tokens", 0)
+        + usage.get("cache_creation_input_tokens", 0)
+    )
+
+
 def map_result_message(
     msg: ResultMessage, start_time: float
 ) -> agent_pb2.AgentEvent:
@@ -77,7 +91,7 @@ def map_result_message(
     return agent_pb2.AgentEvent(
         result=agent_pb2.SessionResult(
             session_id=msg.session_id or "",
-            input_tokens=usage.get("input_tokens", 0),
+            input_tokens=_total_input_tokens(usage),
             output_tokens=usage.get("output_tokens", 0),
             cost_usd=msg.total_cost_usd or 0.0,
             num_turns=msg.num_turns or 0,
@@ -167,7 +181,7 @@ def fallback_result_event(
     return agent_pb2.AgentEvent(
         result=agent_pb2.SessionResult(
             session_id=raw_data.get("session_id", ""),
-            input_tokens=usage.get("input_tokens", 0),
+            input_tokens=_total_input_tokens(usage),
             output_tokens=usage.get("output_tokens", 0),
             cost_usd=raw_data.get("total_cost_usd", 0.0) or 0.0,
             num_turns=raw_data.get("num_turns", 0) or 0,

--- a/packages/agent-worker/tests/test_event_mapper.py
+++ b/packages/agent-worker/tests/test_event_mapper.py
@@ -198,6 +198,24 @@ class TestMapResultMessage:
         assert event.result.result_text == "All done"
         assert event.result.duration_ms > 0
 
+    def test_cached_tokens_included(self):
+        msg = ResultMessage(
+            session_id="sess-cached",
+            usage={
+                "input_tokens": 7,
+                "cache_read_input_tokens": 45000,
+                "cache_creation_input_tokens": 5000,
+                "output_tokens": 631,
+            },
+            total_cost_usd=0.02,
+            num_turns=1,
+            is_error=False,
+            result="Done",
+        )
+        event = map_result_message(msg, start_time=0)
+        assert event.result.input_tokens == 50007  # 7 + 45000 + 5000
+        assert event.result.output_tokens == 631
+
     def test_error_result(self):
         msg = ResultMessage(
             session_id="sess-2",


### PR DESCRIPTION
## Summary
- Include `cache_read_input_tokens` and `cache_creation_input_tokens` in context window calculation
- Fixes misleadingly low context display (e.g., "7/200k ctx" instead of "50k/200k ctx")
- Applies to both `map_result_message` and `fallback_result_event` in event_mapper
- Adds test for cached token scenario

Fixes #29

## Test plan
- [ ] `uv run pytest` passes (including new `test_cached_tokens_included`)
- [ ] Deploy and verify Mattermost shows accurate context counts
- [ ] Verify database `context_tokens` stores correct totals

Generated with [Claude Code](https://claude.com/claude-code)